### PR TITLE
[Roulette] Refactor win-check logic

### DIFF
--- a/game-server/games/roulette/bet/__init__.py
+++ b/game-server/games/roulette/bet/__init__.py
@@ -1,9 +1,9 @@
 from .roulette_bet import RouletteBet
 from .roulette_bet_type import (
     RouletteBetType,
-    EighteenNumberBetType,
-    ColumnBetType,
-    DozenBetType,
+    HighOrLow,
+    Column,
+    Dozen,
 )
 
 from .roulette_bet_impl import (

--- a/game-server/games/roulette/bet/random_bet.py
+++ b/game-server/games/roulette/bet/random_bet.py
@@ -3,9 +3,9 @@ from ..game import RouletteGame, PocketColor
 from . import (
     RouletteBet,
     RouletteBetType,
-    EighteenNumberBetType,
-    ColumnBetType,
-    DozenBetType,
+    HighOrLow,
+    Column,
+    Dozen,
     StraightUpBet,
     SplitBet,
     StreetBet,
@@ -109,7 +109,7 @@ def _random_line_bet(game: RouletteGame) -> RouletteBet:
 
 
 def _random_dozen_bet(game: RouletteGame) -> RouletteBet:
-    bet = Random().choice(list(DozenBetType))
+    bet = Random().choice(list(Dozen))
     return DozenBet(
         bet_amount=Random().uniform(1, 100),
         bet=bet,
@@ -117,7 +117,7 @@ def _random_dozen_bet(game: RouletteGame) -> RouletteBet:
 
 
 def _random_column_bet(game: RouletteGame) -> RouletteBet:
-    bet = Random().choice(list(ColumnBetType))
+    bet = Random().choice(list(Column))
     return ColumnBet(
         bet_amount=Random().uniform(1, 100),
         bet=bet,
@@ -125,7 +125,7 @@ def _random_column_bet(game: RouletteGame) -> RouletteBet:
 
 
 def _random_eighteen_number_bet(game: RouletteGame) -> RouletteBet:
-    bet = Random().choice(list(EighteenNumberBetType))
+    bet = Random().choice(list(HighOrLow))
     return EighteenNumberBet(
         bet_amount=Random().uniform(1, 100),
         bet=bet,

--- a/game-server/games/roulette/bet/roulette_bet_impl.py
+++ b/game-server/games/roulette/bet/roulette_bet_impl.py
@@ -9,7 +9,7 @@ from .roulette_bet_type import (
     RouletteBetType,
 )
 from .roulette_bet import RouletteBet
-from ..game.roulette_pocket import PocketColor, RoulettePocket
+from ..game.roulette_pocket import PocketColor, RoulettePocket, WinningPocket
 
 
 def _generate_id() -> str:
@@ -38,7 +38,7 @@ class StraightUpBet(RouletteBet):
         self.bet_amount = bet_amount
         self.pocket = pocket
 
-    def compute_winnings(self, winning_pocket: RoulettePocket):
+    def compute_winnings(self, winning_pocket: WinningPocket):
         if winning_pocket == self.pocket:
             self.amount_won = self.bet_amount * 35
 
@@ -60,7 +60,7 @@ class SplitBet(RouletteBet):
         self.bet_amount = bet_amount
         self.pockets = pockets
 
-    def compute_winnings(self, winning_pocket: RoulettePocket):
+    def compute_winnings(self, winning_pocket: WinningPocket):
         if winning_pocket in self.pockets:
             self.amount_won = self.bet_amount * 17
 
@@ -82,7 +82,7 @@ class StreetBet(RouletteBet):
         self.bet_amount = bet_amount
         self.pockets = pockets
 
-    def compute_winnings(self, winning_pocket: RoulettePocket):
+    def compute_winnings(self, winning_pocket: WinningPocket):
         if winning_pocket in self.pockets:
             self.amount_won = self.bet_amount * 11
 
@@ -101,7 +101,7 @@ class FiveNumberBet(RouletteBet):
         self.id = _generate_id()
         self.bet_amount = bet_amount
 
-    def compute_winnings(self, winning_pocket: RoulettePocket):
+    def compute_winnings(self, winning_pocket: WinningPocket):
         if winning_pocket.pocket_number <= 3:
             self.amount_won = self.bet_amount * 11
 
@@ -123,7 +123,7 @@ class LineBet(RouletteBet):
         self.bet_amount = bet_amount
         self.pockets = pockets
 
-    def compute_winnings(self, winning_pocket: RoulettePocket):
+    def compute_winnings(self, winning_pocket: WinningPocket):
         if winning_pocket in self.pockets:
             self.amount_won = self.bet_amount * 5
 
@@ -145,18 +145,8 @@ class DozenBet(RouletteBet):
         self.bet_amount = bet_amount
         self.bet = bet
 
-    def compute_winnings(self, winning_pocket: RoulettePocket):
-        if winning_pocket.pocket_number <= 0:
-            return
-        winning_bet: Dozen
-        if winning_pocket.pocket_number <= 12:
-            winning_bet = Dozen.FIRST_DOZEN
-        elif winning_pocket.pocket_number <= 24:
-            winning_bet = Dozen.SECOND_DOZEN
-        else:
-            winning_bet = Dozen.THIRD_DOZEN
-
-        if winning_bet == self.bet:
+    def compute_winnings(self, winning_pocket: WinningPocket):
+        if winning_pocket.dozen == self.bet:
             self.amount_won = self.bet_amount * 2
 
 
@@ -177,18 +167,8 @@ class ColumnBet(RouletteBet):
         self.bet_amount = bet_amount
         self.bet = bet
 
-    def compute_winnings(self, winning_pocket: RoulettePocket):
-        if winning_pocket.pocket_number <= 0:
-            return
-        winning_bet: Column
-        if winning_pocket.pocket_number % 3 == 1:
-            winning_bet = Column.FIRST_COLUMN
-        elif winning_pocket.pocket_number % 3 == 2:
-            winning_bet = Column.SECOND_COLUMN
-        else:
-            winning_bet = Column.THIRD_COLUMN
-
-        if winning_bet == self.bet:
+    def compute_winnings(self, winning_pocket: WinningPocket):
+        if winning_pocket.column == self.bet:
             self.amount_won = self.bet_amount * 2
 
 
@@ -209,13 +189,8 @@ class EighteenNumberBet(RouletteBet):
         self.bet_amount = bet_amount
         self.bet = bet
 
-    def compute_winnings(self, winning_pocket: RoulettePocket):
-        if winning_pocket.pocket_number <= 0:
-            return
-        winning_bet: HighOrLow = (
-            HighOrLow.LOW if winning_pocket.pocket_number <= 18 else HighOrLow.HIGH
-        )
-        if self.bet == winning_bet:
+    def compute_winnings(self, winning_pocket: WinningPocket):
+        if winning_pocket.high_or_low == self.bet:
             self.amount_won = self.bet_amount
 
 
@@ -236,7 +211,7 @@ class ColorBet(RouletteBet):
         self.bet_amount = bet_amount
         self.bet = bet
 
-    def compute_winnings(self, winning_pocket: RoulettePocket):
+    def compute_winnings(self, winning_pocket: WinningPocket):
         if winning_pocket.pocket_color == self.bet:
             self.amount_won = self.bet_amount
 
@@ -257,10 +232,6 @@ class OddOrEvenBet(RouletteBet):
         self.bet_amount = bet_amount
         self.type = bet
 
-    def compute_winnings(self, winning_pocket: RoulettePocket):
-        remainder = 1 if self.type == RouletteBetType.ODD else 0
-        winning_pocket_number = (
-            0 if winning_pocket.pocket_number < 0 else winning_pocket.pocket_number
-        )
-        if winning_pocket_number % 2 == remainder:
+    def compute_winnings(self, winning_pocket: WinningPocket):
+        if winning_pocket.odd_or_even == self.type:
             self.amount_won = self.bet_amount

--- a/game-server/games/roulette/bet/roulette_bet_impl.py
+++ b/game-server/games/roulette/bet/roulette_bet_impl.py
@@ -3,9 +3,9 @@ from random import Random
 import string
 from typing import List
 from .roulette_bet_type import (
-    ColumnBetType,
-    DozenBetType,
-    EighteenNumberBetType,
+    Column,
+    Dozen,
+    HighOrLow,
     RouletteBetType,
 )
 from .roulette_bet import RouletteBet
@@ -134,12 +134,12 @@ class DozenBet(RouletteBet):
     type: RouletteBetType = RouletteBetType.DOZEN
     bet_amount: float = None
     amount_won: float = None
-    bet: DozenBetType = None
+    bet: Dozen = None
 
     def __init__(
         self,
         bet_amount: float,
-        bet: DozenBetType,
+        bet: Dozen,
     ) -> None:
         self.id = _generate_id()
         self.bet_amount = bet_amount
@@ -148,13 +148,13 @@ class DozenBet(RouletteBet):
     def compute_winnings(self, winning_pocket: RoulettePocket):
         if winning_pocket.pocket_number <= 0:
             return
-        winning_bet: DozenBetType
+        winning_bet: Dozen
         if winning_pocket.pocket_number <= 12:
-            winning_bet = DozenBetType.FIRST_DOZEN
+            winning_bet = Dozen.FIRST_DOZEN
         elif winning_pocket.pocket_number <= 24:
-            winning_bet = DozenBetType.SECOND_DOZEN
+            winning_bet = Dozen.SECOND_DOZEN
         else:
-            winning_bet = DozenBetType.THIRD_DOZEN
+            winning_bet = Dozen.THIRD_DOZEN
 
         if winning_bet == self.bet:
             self.amount_won = self.bet_amount * 2
@@ -166,12 +166,12 @@ class ColumnBet(RouletteBet):
     type: RouletteBetType = RouletteBetType.COLUMN
     bet_amount: float = None
     amount_won: float = None
-    bet: ColumnBetType = None
+    bet: Column = None
 
     def __init__(
         self,
         bet_amount: float,
-        bet: ColumnBetType,
+        bet: Column,
     ) -> None:
         self.id = _generate_id()
         self.bet_amount = bet_amount
@@ -180,13 +180,13 @@ class ColumnBet(RouletteBet):
     def compute_winnings(self, winning_pocket: RoulettePocket):
         if winning_pocket.pocket_number <= 0:
             return
-        winning_bet: ColumnBetType
+        winning_bet: Column
         if winning_pocket.pocket_number % 3 == 1:
-            winning_bet = ColumnBetType.FIRST_COLUMN
+            winning_bet = Column.FIRST_COLUMN
         elif winning_pocket.pocket_number % 3 == 2:
-            winning_bet = ColumnBetType.SECOND_COLUMN
+            winning_bet = Column.SECOND_COLUMN
         else:
-            winning_bet = ColumnBetType.THIRD_COLUMN
+            winning_bet = Column.THIRD_COLUMN
 
         if winning_bet == self.bet:
             self.amount_won = self.bet_amount * 2
@@ -198,12 +198,12 @@ class EighteenNumberBet(RouletteBet):
     type: RouletteBetType = RouletteBetType.EIGHTEEN_NUMBER_BET
     bet_amount: float = None
     amount_won: float = None
-    bet: EighteenNumberBetType = None
+    bet: HighOrLow = None
 
     def __init__(
         self,
         bet_amount: float,
-        bet: EighteenNumberBetType,
+        bet: HighOrLow,
     ) -> None:
         self.id = _generate_id()
         self.bet_amount = bet_amount
@@ -212,10 +212,8 @@ class EighteenNumberBet(RouletteBet):
     def compute_winnings(self, winning_pocket: RoulettePocket):
         if winning_pocket.pocket_number <= 0:
             return
-        winning_bet: EighteenNumberBetType = (
-            EighteenNumberBetType.FIRST_EIGHTEEN
-            if winning_pocket.pocket_number <= 18
-            else EighteenNumberBetType.SECOND_EIGHTEEN
+        winning_bet: HighOrLow = (
+            HighOrLow.LOW if winning_pocket.pocket_number <= 18 else HighOrLow.HIGH
         )
         if self.bet == winning_bet:
             self.amount_won = self.bet_amount

--- a/game-server/games/roulette/bet/roulette_bet_type.py
+++ b/game-server/games/roulette/bet/roulette_bet_type.py
@@ -15,18 +15,18 @@ class RouletteBetType(Enum):
     EVEN: str = "EVEN"
 
 
-class DozenBetType(Enum):
+class Dozen(Enum):
     FIRST_DOZEN: str = "FIRST_DOZEN"
     SECOND_DOZEN: str = "SECOND_DOZEN"
     THIRD_DOZEN: str = "THIRD_DOZEN"
 
 
-class EighteenNumberBetType(Enum):
-    FIRST_EIGHTEEN: str = "FIRST_EIGHTEEN"
-    SECOND_EIGHTEEN: str = "SECOND_EIGHTEEN"
+class HighOrLow(Enum):
+    LOW: str = "LOW"
+    HIGH: str = "HIGH"
 
 
-class ColumnBetType(Enum):
+class Column(Enum):
     FIRST_COLUMN: str = "FIRST_COLUMN"
     SECOND_COLUMN: str = "SECOND_COLUMN"
     THIRD_COLUMN: str = "THIRD_COLUMN"

--- a/game-server/games/roulette/game/roulette_game.py
+++ b/game-server/games/roulette/game/roulette_game.py
@@ -1,12 +1,12 @@
 from random import Random
 from typing import List
-from .roulette_pocket import RoulettePocket, PocketColor
+from .roulette_pocket import RoulettePocket, PocketColor, WinningPocket
 from ..bet.roulette_bet import RouletteBet
 
 
 class RouletteGame:
     __pockets = List[RoulettePocket]
-    __winning_pocket: RoulettePocket = None
+    __winning_pocket: WinningPocket = None
     __bets: List[RouletteBet] = []
 
     def __init__(self):
@@ -15,14 +15,14 @@ class RouletteGame:
         self.__bets = []
 
     def spin(self):
-        self.__winning_pocket = self.pocket_from_pocket_number(
-            pocket_number=Random().randint(-1, 36)
+        self.__winning_pocket = WinningPocket(
+            pocket_number=Random().randint(-1, 36),
         )
 
         for bet in self.__bets:
             bet.compute_winnings(self.__winning_pocket)
 
-    def get_winning_pocket(self) -> RoulettePocket:
+    def get_winning_pocket(self) -> WinningPocket:
         return self.__winning_pocket
 
     def get_winning_bets(self) -> List[RouletteBet]:

--- a/game-server/games/roulette/game/roulette_game.py
+++ b/game-server/games/roulette/game/roulette_game.py
@@ -13,7 +13,6 @@ class RouletteGame:
         self.__pockets = [RoulettePocket(pocket_number=i) for i in range(-1, 37)]
         self.__winning_pocket = None
         self.__bets = []
-        self.__winning_pocket = []
 
     def spin(self):
         self.__winning_pocket = self.pocket_from_pocket_number(

--- a/game-server/games/roulette/game/roulette_pocket.py
+++ b/game-server/games/roulette/game/roulette_pocket.py
@@ -69,9 +69,7 @@ class WinningPocket(RoulettePocket):
     def __init__(self, pocket_number) -> None:
         self.pocket_number = pocket_number
         self.pocket_color = self._get_pocket_color()
-        self.odd_or_even = (
-            RouletteBetType.EVEN if self.pocket_number % 2 == 0 else RouletteBetType.ODD
-        )
+        self._get_odd_or_even()
         self._get_column_pos()
         self._get_dozen_pos()
         self._get_high_or_low()
@@ -114,3 +112,13 @@ class WinningPocket(RoulettePocket):
         if self.pocket_number <= 0:
             return
         self.high_or_low = HighOrLow.LOW if self.pocket_number <= 18 else HighOrLow.HIGH
+
+    def _get_odd_or_even(self):
+        if self.pocket_number < 0:
+            self.odd_or_even = RouletteBetType.EVEN
+        else:
+            self.odd_or_even = (
+                RouletteBetType.EVEN
+                if self.pocket_number % 2 == 0
+                else RouletteBetType.ODD
+            )

--- a/game-server/games/roulette/game/roulette_pocket.py
+++ b/game-server/games/roulette/game/roulette_pocket.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from ..bet import RouletteBetType, Dozen, Column, HighOrLow
 
 
 class PocketColor(Enum):
@@ -43,3 +44,73 @@ class RoulettePocket:
             self.pocket_number == other.pocket_number
             and self.pocket_color == other.pocket_color
         )
+
+
+class WinningPocket(RoulettePocket):
+    """
+    Represents wining pocket in a Roulette. Contains outside bet details, that not necessary in a normal pocket
+    - [pocket_color]: The color of the winning pocket
+    - [pocket_number]: The number of the winning pocket, -1 being the double-zero (00) and 0 being zero(0)
+    - [odd_or_even]: Is the pocket number even or odd number
+    - [column]: is the pocket located in first, second, or third column
+    - [dozen]: is the pocket located in first, second, or third dozen
+    - [high_or_low]: is the number located in first or second eighteen
+        - first eighteen is LOW
+        - second eighteen is HIGH
+    """
+
+    pocket_color: PocketColor
+    pocket_number: int
+    odd_or_even: RouletteBetType
+    column: Column = None
+    dozen: Dozen = None
+    high_or_low: HighOrLow = None
+
+    def __init__(self, pocket_number) -> None:
+        self.pocket_number = pocket_number
+        self.pocket_color = self._get_pocket_color()
+        self.odd_or_even = (
+            RouletteBetType.EVEN if self.pocket_number % 2 == 0 else RouletteBetType.ODD
+        )
+        self._get_column_pos()
+        self._get_dozen_pos()
+        self._get_high_or_low()
+
+    def _get_pocket_color(self) -> PocketColor:
+        if self.pocket_number <= 0:
+            return PocketColor.GREEN
+        is_even = self.pocket_number % 2 == 0
+        if self.pocket_number <= 10:
+            return PocketColor.BLACK if is_even else PocketColor.RED
+        if self.pocket_number <= 18:
+            return PocketColor.RED if is_even else PocketColor.BLACK
+        if self.pocket_number <= 28:
+            return PocketColor.BLACK if is_even else PocketColor.RED
+
+        return PocketColor.RED if is_even else PocketColor.BLACK
+
+    def _get_column_pos(self) -> Column:
+        if self.pocket_number <= 0:
+            return
+
+        if self.pocket_number % 3 == 1:
+            self.column = Column.FIRST_COLUMN
+        elif self.pocket_number % 3 == 2:
+            self.column = Column.SECOND_COLUMN
+        else:
+            self.column = Column.THIRD_COLUMN
+
+    def _get_dozen_pos(self) -> Column:
+        if self.pocket_number <= 0:
+            return
+        if self.pocket_number <= 12:
+            self.dozen = Dozen.FIRST_DOZEN
+        elif self.pocket_number <= 24:
+            self.dozen = Dozen.SECOND_DOZEN
+        else:
+            self.dozen = Dozen.THIRD_DOZEN
+
+    def _get_high_or_low(self) -> Column:
+        if self.pocket_number <= 0:
+            return
+        self.high_or_low = HighOrLow.LOW if self.pocket_number <= 18 else HighOrLow.HIGH

--- a/game-server/tests/test_roulette.py
+++ b/game-server/tests/test_roulette.py
@@ -14,9 +14,9 @@ from games.roulette.bet import (
     EighteenNumberBet,
     ColorBet,
     OddOrEvenBet,
-    DozenBetType,
-    ColumnBetType,
-    EighteenNumberBetType,
+    Dozen,
+    Column,
+    HighOrLow,
     RouletteBetType,
 )
 
@@ -166,7 +166,7 @@ def test_dozen_bet(game: RouletteGame):
 
     bet = DozenBet(
         bet_amount=100,
-        bet=DozenBetType.FIRST_DOZEN,
+        bet=Dozen.FIRST_DOZEN,
     )
     game.add_bet(bet)
     with patch("random.Random.randint", return_value=9):
@@ -181,7 +181,7 @@ def test_column_bet(game: RouletteGame):
 
     bet = ColumnBet(
         bet_amount=100,
-        bet=ColumnBetType.THIRD_COLUMN,
+        bet=Column.THIRD_COLUMN,
     )
     game.add_bet(bet)
     with patch("random.Random.randint", return_value=9):
@@ -196,7 +196,7 @@ def test_eighteen_number_bet(game: RouletteGame):
 
     bet = EighteenNumberBet(
         bet_amount=100,
-        bet=EighteenNumberBetType.FIRST_EIGHTEEN,
+        bet=HighOrLow.LOW,
     )
     game.add_bet(bet)
     with patch("random.Random.randint", return_value=9):


### PR DESCRIPTION
This PR includes the ff:
- new class `WinningPocket` which is a subclass of `RoulettePocket`
  - `WinningPocket` contains outsidebet details that are not necessary in a normal `RoulettePocket`
- changes in `/roulette` api respnse
  - `winning_pocket` field now contains all the details for outside bets (`WinningPocket`)
- refactored `.compute_winnings` logic in outsidebets `BetType` (`DozenBet`, `ColumnBet`, etc)
  - `compute_winnings` now accepts `winning_pocket: WinningPocket` as an argument 
  - since `winning_pocket` now contains details for outside bets
  - outside-bet details such as Column type, Dozen type, etc are only computed once (on WinningPocket initialization)
  - win-check in compute_pocket method is now a simple equality check
 - fix for a failing test case
   - issue: RouletteGame.__winning_pocket was initialize twice (with a None and an empty List 🤦)